### PR TITLE
Removing the log statement in cmd.js because JSON.stringify was causi…

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -67,8 +67,6 @@ program
                 console.trace(err);
             }
 
-            console.log("config: %s", JSON.stringify(config, null, 2));
-
             // Run tests
             const results = doctest.runTests(files, config);
 


### PR DESCRIPTION
…ng a circular reference